### PR TITLE
Improving code and functionality of the connection phase

### DIFF
--- a/phoebe-client-rs/src/main/java/com/eightkdata/phoebe/client/rs/Either.java
+++ b/phoebe-client-rs/src/main/java/com/eightkdata/phoebe/client/rs/Either.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015, 8Kdata Technology S.L.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation for any purpose,
+ * without fee, and without a written agreement is hereby granted, provided that the above copyright notice and this
+ * paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL 8Kdata BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+ * INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF 8Kdata HAS BEEN
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * 8Kdata SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ * AND 8Kdata HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ */
+
+
+package com.eightkdata.phoebe.client.rs;
+
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * <p>Holds only one instance out of two possible parametrized types.
+ *
+ * <p>The class is marked as @NotThreadSafe as the instance stored may have methods to mutate it,
+ * but the references held by this class are themselves immutable.
+ */
+@NotThreadSafe
+public class Either<T,U> {
+
+    @Nullable final T t;
+    @Nullable final U u;
+
+    public Either(@Nullable T t, @Nullable U u) {
+        checkArgument((null == t) ^ (null == u), "One arg must be null, the other not null");
+
+        this.t = t;
+        this.u = u;
+    }
+
+    public static <T,U> Either<T,U> left(T left) {
+        return new Either<T, U>(left, null);
+    }
+
+    public static <T,U> Either<T,U> right(U right) {
+        return new Either<T, U>(null, right);
+    }
+
+    public boolean isLeft() {
+        return t != null;
+    }
+
+    public boolean isRight() {
+        return u != null;
+    }
+
+    @Nullable public T getLeft() {
+        return t;
+    }
+
+    @Nullable public U getRight() {
+        return u;
+    }
+
+}

--- a/phoebe-client-rs/src/main/java/com/eightkdata/phoebe/client/rs/FailedConnectionException.java
+++ b/phoebe-client-rs/src/main/java/com/eightkdata/phoebe/client/rs/FailedConnectionException.java
@@ -19,14 +19,29 @@
 package com.eightkdata.phoebe.client.rs;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  *
  */
-public interface PostgresConnection {
+public class FailedConnectionException extends Exception {
 
-    void close();
+    public FailedConnectionException(@Nonnull String message) {
+        super(checkNotNull(message));
+    }
 
-    @Nonnull String host();
+    public FailedConnectionException(@Nonnull String message, @Nullable Throwable cause) {
+        super(checkNotNull(message), cause);
+    }
+
+    @Override
+    public String toString() {
+        return "FailedConnection{" +
+                "message='" + getMessage() + '\'' +
+                ", cause=" + getCause() +
+                '}';
+    }
 
 }

--- a/phoebe-client-rs/src/main/java/com/eightkdata/phoebe/client/rs/PostgresClient.java
+++ b/phoebe-client-rs/src/main/java/com/eightkdata/phoebe/client/rs/PostgresClient.java
@@ -21,12 +21,19 @@ package com.eightkdata.phoebe.client.rs;
 
 import org.reactivestreams.Publisher;
 
+import javax.annotation.Nonnull;
+
 /**
  *
  */
 public interface PostgresClient {
-    Publisher<PostgresConnection> connections();
-    Publisher<PostgresConnection> onConnected();
-    Publisher<PostgresConnection> onFailed();
+
+    @Nonnull Publisher<Either<PostgresConnection,FailedConnectionException>> connections();
+
+    @Nonnull Publisher<PostgresConnection> onConnected();
+
+    @Nonnull Publisher<FailedConnectionException> onFailed();
+
     void close();
+
 }

--- a/phoebe-client-rs/src/test/java/com/eightkdata/phoebe/client/rs/EitherTest.java
+++ b/phoebe-client-rs/src/test/java/com/eightkdata/phoebe/client/rs/EitherTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015, 8Kdata Technology S.L.
+ *
+ * Permission to use, copy, modify, and distribute this software and its documentation for any purpose,
+ * without fee, and without a written agreement is hereby granted, provided that the above copyright notice and this
+ * paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL 8Kdata BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+ * INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF 8Kdata HAS BEEN
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * 8Kdata SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ * AND 8Kdata HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ */
+
+
+package com.eightkdata.phoebe.client.rs;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EitherTest {
+
+    private final Integer left = 42;
+    private final String right = "Right";
+
+    @Test
+    public void testConstructorAndGetters() {
+        testLeftRight(
+                new Either<Integer, String>(left, null),
+                new Either<Integer, String>(null, right)
+        );
+    }
+
+    @Test
+    public void testStaticCreatorsAndGetters() {
+        testLeftRight(
+                Either.<Integer,String>left(left),
+                Either.<Integer,String>right(right)
+        );
+    }
+
+    private <T,U> void testLeftRight(Either<T,U> leftEither, Either<T,U> rightEither) {
+        assertEquals(left, leftEither.getLeft());
+        assertEquals(null, leftEither.getRight());
+        assertTrue(leftEither.isLeft());
+        assertTrue(! leftEither.isRight());
+
+        assertEquals(right, rightEither.getRight());
+        assertEquals(null, rightEither.getLeft());
+        assertTrue(! rightEither.isLeft());
+        assertTrue(rightEither.isRight());
+    }
+
+    @Test
+    public void testIllegalArgumentException() {
+        int nExceptions = 0;
+        try {
+            new Either<Integer,String>(left, right);
+        } catch (IllegalArgumentException e) {
+            nExceptions++;
+        }
+        try {
+            new Either<Integer,String>(null, null);
+        } catch (IllegalArgumentException e) {
+            nExceptions++;
+        }
+
+        assertEquals("Wrong constructor arguments should throw IllegalArgumentExceptions", 2, nExceptions);
+    }
+
+}


### PR DESCRIPTION
Created class Either<T,U> which hold either an instance of T or U. This
class is now the basis for the Observable/Publisher return method of
PostgresConnection.connections(). No longer successful and failed
connections are mixed here in a single class, both are now separated
class.

Code is now cleaner and type safer, while more readable. All in all,
good win IMHO.

This was based on ianp's suggestion:
https://groups.google.com/d/msg/phoebe/xsxZ-B1ctq4/C-kpH7hjDQAJ
